### PR TITLE
Use lstatSync() instead of existsSync()

### DIFF
--- a/src/webpack-symlink-gem.js
+++ b/src/webpack-symlink-gem.js
@@ -18,10 +18,15 @@ function gemShowCmd(gem) {
 
 function clean(rootPath, gem) {
   const path = localPath(rootPath, gem);
-  const stats = fs.lstatSync(path)
 
-  if (stats.isSymbolicLink()) {
-    fs.unlinkSync(path);
+  try {
+    const stats = fs.lstatSync(path);
+
+    if (stats.isSymbolicLink()) {
+      fs.unlinkSync(path);
+    }
+  } catch(err) {
+    if (err.code != 'ENOENT') throw err;
   }
 }
 

--- a/src/webpack-symlink-gem.js
+++ b/src/webpack-symlink-gem.js
@@ -18,8 +18,9 @@ function gemShowCmd(gem) {
 
 function clean(rootPath, gem) {
   const path = localPath(rootPath, gem);
+  const stats = fs.lstatSync(path)
 
-  if (fs.existsSync(path)) {
+  if (stats.isSymbolicLink()) {
     fs.unlinkSync(path);
   }
 }


### PR DESCRIPTION
existsSync() follows symbolic links. Meaning it will return false for
symbolic link that exists but points to a non-existing file.

[Causes builds to fail](https://circleci.com/gh/carwow/dealers_site/96543).

For this reason:
<img width="1044" alt="screen shot 2018-09-12 at 09 36 09" src="https://user-images.githubusercontent.com/7707413/45412725-afb46a00-b677-11e8-8d92-f4363e19c022.png">
